### PR TITLE
don't reset forms after prefilling it

### DIFF
--- a/src/GUIController/QOpenDatabaseViewController.cpp
+++ b/src/GUIController/QOpenDatabaseViewController.cpp
@@ -268,7 +268,6 @@ void QOpenDatabaseViewController::loadDatabase(const DatabaseModel&  databaseMod
 
 void QOpenDatabaseViewController::openConnectionMenu(int index)
 {
-	resetForms();
 	switch (index) {
 		case 0:
 			m_pOpenDatabaseView->openSQLiteMenu();


### PR DESCRIPTION
Previously, clicking on an item in the history list would result in the default values being prefilled, rendering the history list useless. This was caused by this `resetForms()` being called after the history data was filled in.
I removed it instead of adding a check instead, because I could not find any use case where it actually accomplished something which would be affected by this change.