### PR TITLE
Fix incomplete type error

### DIFF
--- a/src/Widget/QDropAreaWidget.cpp
+++ b/src/Widget/QDropAreaWidget.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <QPainter>
+#include <QPainterPath>
 
 #include "QDropAreaWidget.h"
 


### PR DESCRIPTION
src/Widget/QDropAreaWidget.cpp:41:15:  error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined